### PR TITLE
Ajustei o form de tema (detalhes na descrição)

### DIFF
--- a/portalcompass/src/main/java/com/compass/portalcompass/dto/TemaFormDTO.java
+++ b/portalcompass/src/main/java/com/compass/portalcompass/dto/TemaFormDTO.java
@@ -1,12 +1,6 @@
 package com.compass.portalcompass.dto;
 
-import java.util.List;
-
 import javax.validation.constraints.NotEmpty;
-
-import com.compass.portalcompass.entities.MaterialDeEstudo;
-import com.compass.portalcompass.entities.Sprint;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +11,4 @@ public class TemaFormDTO {
 	private Long id;
 	@NotEmpty(message = "Precisa preencher o nome")
 	private String nome;
-	private Sprint sprint;
-	private List<MaterialDeEstudo> materiaisDeEstudo;
 }

--- a/portalcompass/src/main/java/com/compass/portalcompass/dto/TemaFormDTO.java
+++ b/portalcompass/src/main/java/com/compass/portalcompass/dto/TemaFormDTO.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TemaFormDTO {
 
-	private Long id;
 	@NotEmpty(message = "Precisa preencher o nome")
 	private String nome;
 }

--- a/portalcompass/src/main/java/com/compass/portalcompass/entities/Estagiario.java
+++ b/portalcompass/src/main/java/com/compass/portalcompass/entities/Estagiario.java
@@ -2,8 +2,7 @@ package com.compass.portalcompass.entities;
 
 import java.util.List;
 
-
-
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -23,6 +22,7 @@ public class Estagiario {
 	@Id
 	private Long matricula;
 	private String nome;
+	@Column(unique = true)
 	@Email
 	private String email;
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
agora a API não pede ao cliente que envie a lista de materiais, nem a sprint, na hora de cadastrar um tema. Porque esses vínculos são feitos em endpoints específicos para isso. Também acrescentei uma anotação para que não seja possível cadastrar um estagiário com um email repetido.